### PR TITLE
Updated to work with latest core.logic

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject logic-tutorial "1.0.0"
   :description "A Very Gentle Introduction to Relational and Functional Programming"
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.macro "0.1.1"]
-                 [org.clojure/core.logic "0.7.5"]])
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [org.clojure/tools.macro "0.1.2"]
+                 [org.clojure/core.logic "0.8.5"]])

--- a/src/logic_tutorial/tut1.clj
+++ b/src/logic_tutorial/tut1.clj
@@ -1,10 +1,10 @@
 (ns logic-tutorial.tut1
   (:refer-clojure :exclude [==])
-  (:use [clojure.core.logic]))
+  (:use [clojure.core.logic.pldb]))
 
-(defrel parent x y)
-(defrel male x)
-(defrel female x)
+(db-rel parent x y)
+(db-rel male x)
+(db-rel female x)
 
 (defn child [x y]
   (parent y x))


### PR DESCRIPTION
The latest core.logic, 0.8.5, uses a database to wrap facts. This means the tutorial, which Google ranks highly when searching for `core.logic tutorial` is outdated. I updated it to work with core.logic 0.8.5 and clojure 1.5.1. Few changes were required.
