### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ tut1=> (run* [q] (fresh [x y] (== x y) (== y 1) (== q [x y])))
 Multiple Universes
 ----
 
-By now we're already familiar with conjuction, that is, logical **and**.
+By now we're already familiar with conjunction, that is, logical **and**.
 
 ```clj
 (with-dbs [facts fun-people] (run* [q] (fun q) (likes q 'Mary)))


### PR DESCRIPTION
@swannodette, I've corrected a typographical error in the documentation of the [logic-tutorial](https://github.com/swannodette/logic-tutorial) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
